### PR TITLE
IE11 Support (w/o polyfill)

### DIFF
--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -160,7 +160,9 @@ export default Ember.Mixin.create({
       });
 
       // Copy all the relationships
-      for (let { name, meta } of relationships) {
+      for (let i = 0; i < relationships.length; i++) {
+        let { name, meta } = relationships[i];
+
         if (!isUndefined(overwrite[name])) {
           attrs[name] = overwrite[name];
           continue;


### PR DESCRIPTION
This PR is a simple one(two?)-liner that fixes IE11 support. The gist is `for... of` gets translated by Babel into a bit of code that uses `Symbol`, which doesn't exist in IE11 (see [here](https://github.com/bvaughn/js-worker-search/pull/6) for a related issue from another repo). Those of us not using the Babel (or some other Symbol) polyfill are a bit out of luck.

Sadly, this does mean replacing the pretty `for... of` loop with an ugly ol' `for(let i =...` construct, but IMO it's better to make this change than require use of a polyfill for a single line of syntactic sugar.


[On a positive note, huge +1 to this addon otherwise. It was posted right at exactly the time I needed to implement this functionality into an app during its last week of development, so you unwittingly prevented a huge dev crunch. Kudos!]