### PR TITLE
Use model's serializer "transformFor" method

### DIFF
--- a/addon/utils/get-transform.js
+++ b/addon/utils/get-transform.js
@@ -15,6 +15,6 @@ const {
  * @return {DS.Transform}
  */
 export default function getTransform(model, type, _meta) {
-  _meta.transforms[type] = _meta.transforms[type] || getOwner(model).lookup(`transform:${type}`);
+  _meta.transforms[type] = _meta.transforms[type] || model.store.serializerFor(model.constructor.modelName).transformFor(type);
   return _meta.transforms[type];
 }


### PR DESCRIPTION
The addon need to use model's serializer "transformFor" method to support all transform's types (like in [ember-data-model-fragments addon](https://github.com/lytics/ember-data-model-fragments/blob/master/addon/ext.js#L280)).