### PR TITLE
Use Ember.Copyable mixin features if present

### DIFF
--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -9,7 +9,8 @@ const {
   Logger,
   guidFor,
   isEmpty,
-  runInDebug
+  runInDebug,
+  canInvoke
 } = Ember;
 
 const {
@@ -138,13 +139,13 @@ export default Ember.Mixin.create({
       ) {
         let value = this.get(name);
 
-        if (
-            (Ember.typeOf(value) === 'instance') &&
-            (Ember.typeOf(value.copy) === 'function')
-        ) {
+        if (canInvoke(value, 'copy')) {
+          // "value" is an Ember.Object using the Ember.Copyable API (if you use
+          // the "Ember Data Model Fragments" addon and "value" is a fragment or
+          // if use your own serializer where you deserialize a value to an
+          // Ember.Object using this Ember.Copyable API)
           value = value.copy(deep);
-        }
-        else {
+        } else {
           let transform = getTransform(this, type, _meta);
 
           // Run the transform on the value. This should guarantee that we get

--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -137,12 +137,21 @@ export default Ember.Mixin.create({
           !PRIMITIVE_TYPES.includes(type)
       ) {
         let value = this.get(name);
-        let transform = getTransform(this, type, _meta);
 
-        // Run the transform on the value. This should guarantee that we get
-        // a new instance.
-        value = transform.serialize(value, attributeOptions);
-        value = transform.deserialize(value, attributeOptions);
+        if (
+            (Ember.typeOf(value) === 'instance') &&
+            (Ember.typeOf(value.copy) === 'function')
+        ) {
+          value = value.copy(deep);
+        }
+        else {
+          let transform = getTransform(this, type, _meta);
+
+          // Run the transform on the value. This should guarantee that we get
+          // a new instance.
+          value = transform.serialize(value, attributeOptions);
+          value = transform.deserialize(value, attributeOptions);
+        }
 
         attrs[name] = value;
       } else {


### PR DESCRIPTION
Hello,

I use [ember-data-model-fragments](https://github.com/lytics/ember-data-model-fragments) and I had a problem when using ember-data-copyable (_ember-data-model-fragments use [own type](https://github.com/lytics/ember-data-model-fragments/blob/master/addon/ext.js#L298) but this could be the same for other addons_) so i sent you [this first PR](https://github.com/offirgolan/ember-data-copyable/pull/5).

But this first PR is not enough to support ember-data-model-fragments. A fragment extends DS.Model and when [ember-data-copyable (de)serialize to get a new value instance](https://github.com/offirgolan/ember-data-copyable/blob/master/addon/mixins/copyable.js#L144), it's [should be a DS.Snapshot](https://github.com/lytics/ember-data-model-fragments/blob/master/addon/transforms/fragment.js#L32) and [not a DS.Model instance which should be passed as argument](https://github.com/offirgolan/ember-data-copyable/blob/master/addon/mixins/copyable.js#L144).

I think it should be better to use `copy` method (cf [Ember.Copyable](https://www.emberjs.com/api/ember/2.14.1/classes/Ember.Copyable)) if `value` is an Ember Object instance and if it use Ember.Copyable mixin. So this new PR.

What do you think about this proposal? Thanks.
