### PR TITLE
Use `Ember.Copyable.detect`

### DIFF
--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -10,7 +10,7 @@ const {
   guidFor,
   isEmpty,
   runInDebug,
-  canInvoke
+  Copyable
 } = Ember;
 
 const {
@@ -139,7 +139,7 @@ export default Ember.Mixin.create({
       ) {
         let value = this.get(name);
 
-        if (canInvoke(value, 'copy')) {
+        if (Copyable && Copyable.detect(value)) {
           // "value" is an Ember.Object using the Ember.Copyable API (if you use
           // the "Ember Data Model Fragments" addon and "value" is a fragment or
           // if use your own serializer where you deserialize a value to an


### PR DESCRIPTION
In my [last merged PR](https://github.com/offirgolan/ember-data-copyable/pull/6), I used `canInvoke` to know if `value` was extending Ember.Copyable. I think it's better to use Ember.Copyable.detect method as in [`Ember.copy` method](https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/copy.js#L93).