### PR TITLE
[Feature] Other Attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,15 @@ Attributes to ignore when copying.
 ignoreAttributes: ['guid', 'address']
 ```
 
+### `otherAttributes`
+
+Other attributes to copy over that are not defined via DS.attr, DS.belongsTo,
+or DS.hasMany.
+
+```js
+otherAttributes: ['timestamp', 'someFlag']
+```
+
 ### `copyByReference`
 
 Attributes to copy only by reference. If the attribute has the `Copyable` mixin, it will

--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -23,6 +23,9 @@ const DEFAULT_OPTIONS = {
   // List of all attributes to ignore
   ignoreAttributes: [],
 
+  // List of other attributes to copy
+  otherAttributes: [],
+
   // List of all attributes to copy by reference
   copyByReference: [],
 
@@ -110,7 +113,7 @@ export default Ember.Mixin.create({
   [COPY_TASK]: task(function *(deep, options, _meta) {
     options = assign({}, DEFAULT_OPTIONS, this.get('copyableOptions'), options);
 
-    let { ignoreAttributes, copyByReference, overwrite } = options;
+    let { ignoreAttributes, otherAttributes, copyByReference, overwrite } = options;
     let { copies } = _meta;
     let { modelName } = this.constructor;
     let store = this.get('store');
@@ -123,7 +126,7 @@ export default Ember.Mixin.create({
       return copies[guid];
     }
 
-    let model  = store.createRecord(modelName);
+    let model = store.createRecord(modelName);
     copies[guid] = model;
 
     // Copy all the attributes
@@ -223,9 +226,9 @@ export default Ember.Mixin.create({
       }
     }
 
-    // Since overwrite can include `id` or other properties that have not been touched
-    // we want to still include them.
-    assign(attrs, overwrite);
+    // Build the final attrs pojo by merging otherAttributes, the copied
+    // attributes, and ant overwrites specified.
+    attrs = assign(this.getProperties(otherAttributes), attrs, overwrite);
 
     // Set the properties on the model
     model.setProperties(attrs);

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}

--- a/tests/integration/copyable-options-test.js
+++ b/tests/integration/copyable-options-test.js
@@ -55,6 +55,26 @@ test('it ignores attributes', async function(assert) {
   });
 });
 
+test('it copes other attributes', async function(assert) {
+  assert.expect(2);
+
+  let model = this.store.peekRecord('bar', 1);
+
+  model.setProperties({
+    one: 1,
+    two: 2
+  });
+
+  await run(async () => {
+    let copy = await model.copy(true, {
+      otherAttributes: ['one', 'two']
+    });
+
+    assert.equal(copy.get('one'), 1);
+    assert.equal(copy.get('two'), 2);
+  });
+});
+
 test('it copies with nested options', async function(assert) {
   assert.expect(3);
 


### PR DESCRIPTION
Closes #8.

### `otherAttributes`

Other attributes to copy over that are not defined via DS.attr, DS.belongsTo,
or DS.hasMany.

```js
otherAttributes: ['timestamp', 'someFlag']
```