### PR TITLE
Shallow Copy should copy over all relationships by reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,11 @@ async function copy(deep = false, options = {}) {};
 
 - `deep` : _Boolean_
 
-    If __false__ a shallow copy of only the model's attributes will be created.
+    If __false__ a shallow copy of the model's attributes will be created.
+    All relationships will be copied over by reference.
 
     If __true__, a deep copy of the model and it's realtionships will be created.
+    If a relational model has the Copyable mixin, it will also be deep copied.
 
 - `options` : _Object_
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ overwrite: {
 ### `relationships`
 
 Specify options to nested models.
+Nested relationships options can also include a `deep` option. If set to false,
+the relationship will be shallow copied.
 
 ```js
 relationships: {
@@ -177,6 +179,9 @@ relationships: {
   },
   friends: {
     copyByReference: ['address']
+  },
+  profile: {
+    deep: false
   }
 }
 ```

--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -118,6 +118,7 @@ export default Ember.Mixin.create({
     let { modelName } = this.constructor;
     let store = this.get('store');
     let guid = guidFor(this);
+    let relationships = [];
     let attrs = {};
 
     // Handle cyclic relationships: If the model has already been copied,
@@ -163,65 +164,64 @@ export default Ember.Mixin.create({
       }
     });
 
-    if (deep) {
-      let relationships = [];
+    // Get all the relationship data
+    this.eachRelationship((name, meta) => {
+      if (!ignoreAttributes.includes(name)) {
+        relationships.push({ name, meta });
+      }
+    });
 
-      // Get all the relationship data
-      this.eachRelationship((name, meta) => {
-        if (!ignoreAttributes.includes(name)) {
-          relationships.push({ name, meta });
-        }
-      });
+    // Copy all the relationships
+    for (let i = 0; i < relationships.length; i++) {
+      let { name, meta } = relationships[i];
+      let relOptions = options.relationships[name];
+      let shouldCopyRelByRef = !deep || (relOptions && relOptions.deep === false);
 
-      // Copy all the relationships
-      for (let i = 0; i < relationships.length; i++) {
-        let { name, meta } = relationships[i];
+      if (!isUndefined(overwrite[name])) {
+        attrs[name] = overwrite[name];
+        continue;
+      }
 
-        if (!isUndefined(overwrite[name])) {
-          attrs[name] = overwrite[name];
-          continue;
-        }
+      // We dont need to yield for a value if it's just copied by ref
+      // or if we are doing a shallow copy
+      if (shouldCopyRelByRef || copyByReference.includes(name)) {
+        try {
+          let ref = this[meta.kind](name);
+          let copyRef = model[meta.kind](name);
 
-        // We dont need to yield for a value if it's just copied by ref.
-        if (copyByReference.includes(name)) {
-          try {
-            let ref = this[meta.kind](name);
-            let copyRef = model[meta.kind](name);
-
-            /*
-              NOTE: This is currently private API but has been approved @igorT.
-                    Supports Ember Data 2.5+
-             */
-            if (meta.kind === 'hasMany') {
-              copyRef.hasManyRelationship.addRecords(ref.hasManyRelationship.members);
-            } else if (meta.kind === 'belongsTo') {
-              copyRef.belongsToRelationship.addRecords(ref.belongsToRelationship.members);
-            }
-          } catch (e) {
-            attrs[name] = this.get(name);
+          /*
+            NOTE: This is currently private API but has been approved @igorT.
+                  Supports Ember Data 2.5+
+            */
+          if (meta.kind === 'hasMany') {
+            copyRef.hasManyRelationship.addRecords(ref.hasManyRelationship.members);
+          } else if (meta.kind === 'belongsTo') {
+            copyRef.belongsToRelationship.addRecords(ref.belongsToRelationship.members);
           }
-
-          continue;
+        } catch (e) {
+          attrs[name] = this.get(name);
         }
 
-        let value = yield this.get(name);
+        continue;
+      }
 
-        if (meta.kind === 'belongsTo') {
-          if (value && value.get(IS_COPYABLE)) {
-            attrs[name] = yield value.get(COPY_TASK).perform(true, options.relationships[name], _meta);
-          } else {
-            attrs[name] = value;
-          }
-        } else if (meta.kind === 'hasMany') {
-          let firstObject = value.get('firstObject');
+      let value = yield this.get(name);
 
-          if (firstObject && firstObject.get(IS_COPYABLE)) {
-            attrs[name] = yield all(
-              value.getEach(COPY_TASK).invoke('perform', true, options.relationships[name], _meta)
-            );
-          } else {
-            attrs[name] = value;
-          }
+      if (meta.kind === 'belongsTo') {
+        if (value && value.get(IS_COPYABLE)) {
+          attrs[name] = yield value.get(COPY_TASK).perform(true, relOptions, _meta);
+        } else {
+          attrs[name] = value;
+        }
+      } else if (meta.kind === 'hasMany') {
+        let firstObject = value.get('firstObject');
+
+        if (firstObject && firstObject.get(IS_COPYABLE)) {
+          attrs[name] = yield all(
+            value.getEach(COPY_TASK).invoke('perform', true, relOptions, _meta)
+          );
+        } else {
+          attrs[name] = value;
         }
       }
     }

--- a/tests/integration/copyable-options-test.js
+++ b/tests/integration/copyable-options-test.js
@@ -100,15 +100,15 @@ test('it copies with nested options', async function(assert) {
 test('it handles relational deep copy overrides', async function(assert) {
   assert.expect(1);
 
-  let model = this.store.peekRecord('bar', 1);
+  let model = this.store.peekRecord('baz', 1);
 
   await run(async () => {
     let copy = await model.copy(true, {
       relationships: {
-        foo: { deep: false }
+        bar: { deep: false }
       }
     });
 
-    assert.equal(copy.get('foo.id'), 1);
+    assert.equal(copy.get('bar.foo.id'), 1);
   });
 });

--- a/tests/integration/copyable-options-test.js
+++ b/tests/integration/copyable-options-test.js
@@ -92,7 +92,23 @@ test('it copies with nested options', async function(assert) {
     });
 
     assert.equal(copy.get('id'), 42);
-    assert.ok(copy.get('foo.id'), 22);
+    assert.equal(copy.get('foo.id'), 22);
     assert.notOk(copy.get('foo.property'));
+  });
+});
+
+test('it handles relational deep copy overrides', async function(assert) {
+  assert.expect(1);
+
+  let model = this.store.peekRecord('bar', 1);
+
+  await run(async () => {
+    let copy = await model.copy(true, {
+      relationships: {
+        foo: { deep: false }
+      }
+    });
+
+    assert.equal(copy.get('foo.id'), 1);
   });
 });

--- a/tests/integration/copyable-tests.js
+++ b/tests/integration/copyable-tests.js
@@ -2,7 +2,8 @@ import Ember from 'ember';
 import { test } from 'ember-qunit';
 
 const {
-  run
+  run,
+  RSVP: { allSettled }
 } = Ember;
 
 export async function getRecord(context, options, modelName, ...args) {
@@ -28,6 +29,29 @@ export default function generateTests(options = { async: false }) {
 
       assert.equal(model.get('property'), copy.get('property'));
       assert.notEqual(copy.get('id'), 1);
+    });
+  });
+
+  test('it shallow copies relationships', async function(assert) {
+    assert.expect(2);
+
+    let model, copy;
+
+    await run(async () => {
+      model = await getRecord(this, options, 'baz', 1);
+    });
+
+    await run(async () => {
+      copy = await model.copy(false);
+    });
+
+    await run(async () => {
+      if (options.async) {
+        await allSettled([ model.get('foos'), model.get('bar') ]);
+      }
+
+      assert.equal(model.get('bar.id'), copy.get('bar.id'));
+      assert.deepEqual(model.get('foos').getEach('id'), copy.get('foos').getEach('id'));
     });
   });
 


### PR DESCRIPTION
Also provide a way to override `deep` copying on a per relationship basis via using the `deep` option in the relationships options pojo.