### PR TITLE
Update ember-cli-dependency-checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-ajax": "^3.0.0",
     "ember-cli": "2.13.2",
     "ember-cli-changelog": "^0.3.4",
-    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-dependency-checker": "^2.1.0",
     "ember-cli-eslint": "^3.0.0",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-cli-htmlbars-inline-precompile": "^0.4.0",


### PR DESCRIPTION
This fixes DEPRECATION: An addon is trying to access project.nodeModulesPath with recent ember-cli versions.