### PR TITLE
 Use `ember-copy` addon to support "Copyable" objects

### DIFF
--- a/addon/mixins/copyable.js
+++ b/addon/mixins/copyable.js
@@ -5,13 +5,13 @@ import { COPY_TASK, COPY_TASK_RUNNER, IS_COPYABLE } from 'ember-data-copyable/-p
 import { task, all } from 'ember-concurrency';
 import { assign } from '@ember/polyfills';
 import { guidFor } from '@ember/object/internals';
+import { Copyable } from 'ember-copy';
 import { isEmpty } from '@ember/utils';
 import { runInDebug } from '@ember/debug';
 import Mixin from '@ember/object/mixin';
 
 const {
   Logger,
-  Copyable
 } = Ember;
 
 const {
@@ -145,7 +145,8 @@ export default Mixin.create({
         let value = this.get(name);
 
         if (Copyable && Copyable.detect(value)) {
-          // "value" is an Ember.Object using the Ember.Copyable API (if you use
+          // "value" is an Ember.Object using the ember-copy addon
+          // (ie. old deprecated Ember.Copyable API - if you use
           // the "Ember Data Model Fragments" addon and "value" is a fragment or
           // if use your own serializer where you deserialize a value to an
           // Ember.Object using this Ember.Copyable API)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
-    "ember-concurrency": "^0.8.5"
+    "ember-concurrency": "^0.8.5",
+    "ember-copy": "^1.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2739,6 +2739,12 @@ ember-concurrency@^0.8.5:
     ember-cli-babel "^6.8.2"
     ember-maybe-import-regenerator "^0.1.5"
 
+ember-copy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-copy/-/ember-copy-1.0.0.tgz#426554ba6cf65920f31d24d0a3ca2cb1be16e4aa"
+  dependencies:
+    ember-cli-babel "^6.6.0"
+
 ember-data@^2.13.1:
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-2.13.1.tgz#fd85daf3c4c7bfe6a0c2e42cedf72048979f94ae"


### PR DESCRIPTION
Hello,

[`Ember.Copyable` is deprecated in Ember v3.x](https://www.emberjs.com/deprecations/v3.x#toc_ember-runtime-deprecate-copy-copyable)