### PR TITLE
allow e-c ^2.0.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.1.2",
-    "ember-concurrency": "^0.8.27 || ^0.9.0 || ^0.10.0 || ^1.0.0",
+    "ember-concurrency": "^0.8.27 || ^0.9.0 || ^0.10.0 || ^1.0.0 || ^2.0.0-rc.1",
     "ember-copy": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
In the same spirit as #30, we can allow ember-concurrency versions 2.0.0-rc.1+.

This is actually mentioned in the migration guide: https://github.com/machty/ember-concurrency/blob/master/UPGRADING-2.x.md#packagejson